### PR TITLE
Adjust providers for ProcessModule

### DIFF
--- a/backend/src/process/process.module.ts
+++ b/backend/src/process/process.module.ts
@@ -1,12 +1,11 @@
 import { Module } from '@nestjs/common';
 import { ProcessService } from './process.service';
 import { ProcessController } from './process.controller';
-import { PrismaService } from '../../prisma/prisma.service';
 import { ProcessingLogService } from './processing-log.service';
 import { SupabaseModule } from 'src/supabase/supabase.module';
-import { SupabaseService } from 'src/supabase/supabase.service';
 import { DownloadsModule } from '../downloads/downloads.module';
 import { PrismaModule } from 'prisma/prisma.module';
+import { DownloadsService } from '../downloads/downloads.service';
 
 @Module({
   imports: [
@@ -16,10 +15,8 @@ import { PrismaModule } from 'prisma/prisma.module';
   ],
   providers: [
     ProcessService,
-    PrismaService,
     ProcessingLogService,
-    SupabaseService,
-    DownloadsModule,
+    DownloadsService,
   ],
   controllers: [ProcessController],
 })


### PR DESCRIPTION
## Summary
- remove unused PrismaService, SupabaseService and DownloadsModule from ProcessModule providers
- add DownloadsService provider
- rely on PrismaModule and SupabaseModule imports for service provision

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68430012bdf0832dbb0b1d3db275a4aa