### PR TITLE
Refactor processors with shared upload helper

### DIFF
--- a/backend/src/strategies/MapaProcessor.ts
+++ b/backend/src/strategies/MapaProcessor.ts
@@ -24,38 +24,11 @@ import {
   processarArquivo289Mapa,
 } from 'src/Regras/MAPA/289/ProcessarArquivo289';
 import { Processador326 } from 'src/Regras/MAPA/326/ProcessarArquivo326Mapa';
-
-interface ProcessedInfo {
-  path: string;
-  size: number;
-}
+import { ProcessedInfo, uploadIfNotEmpty } from '../utils/upload';
 
 @Injectable()
 export class MapaProcessor implements IEmpresaProcessor {
   constructor(private readonly supabaseService: SupabaseService) {}
-
-  private async uploadIfNotEmpty(
-    key: string,
-    filePath: string,
-    codigoSistema: string,
-    result: Record<string, ProcessedInfo>,
-  ) {
-    const stats = fs.statSync(filePath);
-    if (stats.size > 0) {
-      const fileBuffer = fs.readFileSync(filePath);
-      const { supabasePath, error } = await this.supabaseService.uploadProcessedFile(
-        filePath,
-        fileBuffer,
-        codigoSistema,
-      );
-      result[key] = {
-        path: supabasePath,
-        size: stats.size,
-      };
-    } else {
-      fs.unlinkSync(filePath); // remove vazios
-    }
-  }
 
   async processUnificado(
     inputExcelPath: string,
@@ -68,98 +41,98 @@ export class MapaProcessor implements IEmpresaProcessor {
     try {
       const output255 = path.join(outputDir, 'saida255.txt');
       await processarArquivo255(inputExcelPath, output255);
-      await this.uploadIfNotEmpty('regra255', output255, codigoSistema, result);
+      await uploadIfNotEmpty(this.supabaseService, 'regra255', output255, codigoSistema, result);
     } catch {}
 
     // Regra 257-1
     try {
       const output257_1 = path.join(outputDir, 'saida257-1.txt');
       await processarArquivos257_1(inputExcelPath, output257_1);
-      await this.uploadIfNotEmpty('regra257_1', output257_1, codigoSistema, result);
+      await uploadIfNotEmpty(this.supabaseService, 'regra257_1', output257_1, codigoSistema, result);
     } catch {}
 
     // Regra 257-2
     try {
       const output257_2 = path.join(outputDir, 'saida257-2.txt');
       await processarArquivo257_2(inputExcelPath, output257_2);
-      await this.uploadIfNotEmpty('regra257_2', output257_2, codigoSistema, result);
+      await uploadIfNotEmpty(this.supabaseService, 'regra257_2', output257_2, codigoSistema, result);
     } catch {}
 
     // Regra 282
     try {
       const output282 = path.join(outputDir, 'saida282.txt');
       await processarArquivo282(inputExcelPath, output282);
-      await this.uploadIfNotEmpty('regra282', output282, codigoSistema, result);
+      await uploadIfNotEmpty(this.supabaseService, 'regra282', output282, codigoSistema, result);
     } catch {}
 
     // Regra 283
     try {
       const output283 = path.join(outputDir, 'saida283.txt');
       await processarArquivo283(inputExcelPath, output283);
-      await this.uploadIfNotEmpty('regra283', output283, codigoSistema, result);
+      await uploadIfNotEmpty(this.supabaseService, 'regra283', output283, codigoSistema, result);
     } catch {}
 
     // Regra 284-1
     try {
       const output284 = path.join(outputDir, 'saida284.txt');
       await processarArquivo284(inputExcelPath, output284);
-      await this.uploadIfNotEmpty('regra284', output284, codigoSistema, result);
+      await uploadIfNotEmpty(this.supabaseService, 'regra284', output284, codigoSistema, result);
     } catch {}
 
     // Regra 328
     try {
       const output328 = path.join(outputDir, 'saida328.txt');
       await processarArquivo328(inputExcelPath, output328);
-      await this.uploadIfNotEmpty('regra328', output328, codigoSistema, result);
+      await uploadIfNotEmpty(this.supabaseService, 'regra328', output328, codigoSistema, result);
     } catch {}
 
     // Regra 329
     try {
       const output329 = path.join(outputDir, 'saida329.txt');
       await processarArquivo329(inputExcelPath, output329);
-      await this.uploadIfNotEmpty('regra329', output329, codigoSistema, result);
+      await uploadIfNotEmpty(this.supabaseService, 'regra329', output329, codigoSistema, result);
     } catch {}
 
     // Regra 335
     try {
       const output335 = path.join(outputDir, 'saida335.txt');
       await processarArquivo335(inputExcelPath, output335);
-      await this.uploadIfNotEmpty('regra335', output335, codigoSistema, result);
+      await uploadIfNotEmpty(this.supabaseService, 'regra335', output335, codigoSistema, result);
     } catch {}
 
     // Regra 336
     try {
       const output336 = path.join(outputDir, 'saida336.txt');
       await processarArquivo336(inputExcelPath, output336);
-      await this.uploadIfNotEmpty('regra336', output336, codigoSistema, result);
+      await uploadIfNotEmpty(this.supabaseService, 'regra336', output336, codigoSistema, result);
     } catch {}
 
     // Regra 337
     try {
       const output337 = path.join(outputDir, 'saida337.txt');
       await processarArquivo337(inputExcelPath, output337);
-      await this.uploadIfNotEmpty('regra337', output337, codigoSistema, result);
+      await uploadIfNotEmpty(this.supabaseService, 'regra337', output337, codigoSistema, result);
     } catch {}
 
     // Regra 347
     try {
       const output347 = path.join(outputDir, 'saida347.txt');
       await processarArquivo347(inputExcelPath, output347);
-      await this.uploadIfNotEmpty('regra347', output347, codigoSistema, result);
+      await uploadIfNotEmpty(this.supabaseService, 'regra347', output347, codigoSistema, result);
     } catch {}
 
     // Regra 349
     try {
       const output349 = path.join(outputDir, 'saida349.txt');
       await processarArquivo349(inputExcelPath, output349);
-      await this.uploadIfNotEmpty('regra349', output349, codigoSistema, result);
+      await uploadIfNotEmpty(this.supabaseService, 'regra349', output349, codigoSistema, result);
     } catch {}
 
     // Regra 350
     try {
       const output350 = path.join(outputDir, 'saida350.txt');
       await processarArquivo350(inputExcelPath, output350);
-      await this.uploadIfNotEmpty('regra350', output350, codigoSistema, result);
+      await uploadIfNotEmpty(this.supabaseService, 'regra350', output350, codigoSistema, result);
     } catch {}
 
     // Se não for mais necessário normalizar o caminho local, pode remover essa parte.

--- a/backend/src/strategies/NpProcessor.ts
+++ b/backend/src/strategies/NpProcessor.ts
@@ -22,38 +22,12 @@ import { processarArquivo350 as processarArquivo350Np } from 'src/Regras/NP/350/
 import { processarArquivo289NP } from 'src/Regras/NP/289/ProcessarArquivo289';
 import { Processador326 } from 'src/Regras/NP/326/ProcessarArquivo326';
 import { exportToTxt289 } from 'src/Regras/NP/289/ProcessarArquivo289';
-
-interface ProcessedInfo {
-  path: string;
-  size: number;
-}
+import { ProcessedInfo, uploadIfNotEmpty } from '../utils/upload';
 
 @Injectable()
 export class NpProcessor implements IEmpresaProcessor {
   constructor(private readonly supabaseService: SupabaseService) {}
 
-  private async uploadIfNotEmpty(
-    key: string,
-    filePath: string,
-    codigoSistema: string,
-    result: Record<string, ProcessedInfo>,
-  ) {
-    const stats = fs.statSync(filePath);
-    if (stats.size > 0) {
-      const fileBuffer = fs.readFileSync(filePath);
-      const { supabasePath } = await this.supabaseService.uploadProcessedFile(
-        filePath,
-        fileBuffer,
-        codigoSistema,
-      );
-      result[key] = {
-        path: supabasePath,
-        size: stats.size,
-      };
-    } else {
-      fs.unlinkSync(filePath);
-    }
-  }
 
   async processUnificado(
     inputExcelPath: string,
@@ -66,85 +40,85 @@ export class NpProcessor implements IEmpresaProcessor {
     try {
       const out255 = path.join(outputDir, 'saida255.txt');
       await processarArquivo255Np(inputExcelPath, out255);
-      await this.uploadIfNotEmpty('regra255', out255, codigoSistema, result);
+      await uploadIfNotEmpty(this.supabaseService, 'regra255', out255, codigoSistema, result);
     } catch {}
 
     try {
       const out2571 = path.join(outputDir, 'saida257-1.txt');
       await processarArquivo257_1Np(inputExcelPath, out2571);
-      await this.uploadIfNotEmpty('regra257_1', out2571, codigoSistema, result);
+      await uploadIfNotEmpty(this.supabaseService, 'regra257_1', out2571, codigoSistema, result);
     } catch {}
 
     try {
       const out2572 = path.join(outputDir, 'saida257-2.txt');
       await processarArquivo257_2Np(inputExcelPath, out2572);
-      await this.uploadIfNotEmpty('regra257_2', out2572, codigoSistema, result);
+      await uploadIfNotEmpty(this.supabaseService, 'regra257_2', out2572, codigoSistema, result);
     } catch {}
 
     try {
       const out282 = path.join(outputDir, 'saida282.txt');
       await processarArquivo282Np(inputExcelPath, out282);
-      await this.uploadIfNotEmpty('regra282', out282, codigoSistema, result);
+      await uploadIfNotEmpty(this.supabaseService, 'regra282', out282, codigoSistema, result);
     } catch {}
 
     try {
       const out283 = path.join(outputDir, 'saida283.txt');
       await processarArquivo283Np(inputExcelPath, out283);
-      await this.uploadIfNotEmpty('regra283', out283, codigoSistema, result);
+      await uploadIfNotEmpty(this.supabaseService, 'regra283', out283, codigoSistema, result);
     } catch {}
 
     try {
       const out284 = path.join(outputDir, 'saida284.txt');
       await processarArquivo284Np(inputExcelPath, out284);
-      await this.uploadIfNotEmpty('regra284', out284, codigoSistema, result);
+      await uploadIfNotEmpty(this.supabaseService, 'regra284', out284, codigoSistema, result);
     } catch {}
 
     try {
       const out328 = path.join(outputDir, 'saida328.txt');
       await processarArquivo328Np(inputExcelPath, out328);
-      await this.uploadIfNotEmpty('regra328', out328, codigoSistema, result);
+      await uploadIfNotEmpty(this.supabaseService, 'regra328', out328, codigoSistema, result);
     } catch {}
 
     try {
       const out329 = path.join(outputDir, 'saida329.txt');
       await processarArquivo329Np(inputExcelPath, out329);
-      await this.uploadIfNotEmpty('regra329', out329, codigoSistema, result);
+      await uploadIfNotEmpty(this.supabaseService, 'regra329', out329, codigoSistema, result);
     } catch {}
 
     try {
       const out335 = path.join(outputDir, 'saida335.txt');
       await processarArquivo335Np(inputExcelPath, out335);
-      await this.uploadIfNotEmpty('regra335', out335, codigoSistema, result);
+      await uploadIfNotEmpty(this.supabaseService, 'regra335', out335, codigoSistema, result);
     } catch {}
 
     try {
       const out336 = path.join(outputDir, 'saida336.txt');
       await processarArquivo336Np(inputExcelPath, out336);
-      await this.uploadIfNotEmpty('regra336', out336, codigoSistema, result);
+      await uploadIfNotEmpty(this.supabaseService, 'regra336', out336, codigoSistema, result);
     } catch {}
 
     try {
       const out337 = path.join(outputDir, 'saida337.txt');
       await processarArquivo337Np(inputExcelPath, out337);
-      await this.uploadIfNotEmpty('regra337', out337, codigoSistema, result);
+      await uploadIfNotEmpty(this.supabaseService, 'regra337', out337, codigoSistema, result);
     } catch {}
 
     try {
       const out347 = path.join(outputDir, 'saida347.txt');
       await processarArquivo347Np(inputExcelPath, out347);
-      await this.uploadIfNotEmpty('regra347', out347, codigoSistema, result);
+      await uploadIfNotEmpty(this.supabaseService, 'regra347', out347, codigoSistema, result);
     } catch {}
 
     try {
       const out349 = path.join(outputDir, 'saida349.txt');
       await processarArquivo349Np(inputExcelPath, out349);
-      await this.uploadIfNotEmpty('regra349', out349, codigoSistema, result);
+      await uploadIfNotEmpty(this.supabaseService, 'regra349', out349, codigoSistema, result);
     } catch {}
 
     try {
       const out350 = path.join(outputDir, 'saida350.txt');
       await processarArquivo350Np(inputExcelPath, out350);
-      await this.uploadIfNotEmpty('regra350', out350, codigoSistema, result);
+      await uploadIfNotEmpty(this.supabaseService, 'regra350', out350, codigoSistema, result);
     } catch {}
 
     return result;

--- a/backend/src/strategies/TelhacoProcessor.ts
+++ b/backend/src/strategies/TelhacoProcessor.ts
@@ -24,38 +24,11 @@ import {
   processarArquivo289Telhacao,
 } from 'src/Regras/TELHAÇO/289/ProcessarArquivo289';
 import { Processador326 } from 'src/Regras/TELHAÇO/326/ProcessarArquivo326';
-
-interface ProcessedInfo {
-  path: string;
-  size: number;
-}
+import { ProcessedInfo, uploadIfNotEmpty } from '../utils/upload';
 
 @Injectable()
 export class TelhacoProcessor implements IEmpresaProcessor {
   constructor(private supabaseService: SupabaseService) {}
-
-  private async uploadIfNotEmpty(
-    key: string,
-    filePath: string,
-    codigoSistema: string,
-    result: Record<string, ProcessedInfo>,
-  ) {
-    const stats = fs.statSync(filePath);
-    if (stats.size > 0) {
-      const fileBuffer = fs.readFileSync(filePath);
-      const { supabasePath, error } = await this.supabaseService.uploadProcessedFile(
-        filePath,
-        fileBuffer,
-        codigoSistema,
-      );
-      result[key] = {
-        path: supabasePath,
-        size: stats.size,
-      };
-    } else {
-      fs.unlinkSync(filePath); // remove vazios
-    }
-  }
 
   async processUnificado(
     inputExcelPath: string,
@@ -68,7 +41,7 @@ export class TelhacoProcessor implements IEmpresaProcessor {
     try {
       const output255 = path.join(outputDir, 'saida255.txt');
       await processarArquivo255Telhaco(inputExcelPath, output255);
-      await this.uploadIfNotEmpty('regra255', output255, codigoSistema, result);
+      await uploadIfNotEmpty(this.supabaseService, 'regra255', output255, codigoSistema, result);
     } catch {}
     
 
@@ -76,91 +49,91 @@ export class TelhacoProcessor implements IEmpresaProcessor {
     try {
       const output2571 = path.join(outputDir, 'saida257-1.txt');
       await processarArquivos257_1Telhaco(inputExcelPath, output2571);
-      await this.uploadIfNotEmpty('regra257_1', output2571, codigoSistema, result);
+      await uploadIfNotEmpty(this.supabaseService, 'regra257_1', output2571, codigoSistema, result);
     } catch {}
 
     // Regra 257_2
     try {
       const output2572 = path.join(outputDir, 'saida257_2.txt');
       await processarArquivos257_2Telhaco(inputExcelPath, output2572);
-      await this.uploadIfNotEmpty('regra257_2', output2572, codigoSistema, result);
+      await uploadIfNotEmpty(this.supabaseService, 'regra257_2', output2572, codigoSistema, result);
     } catch {}
 
     // Regra 282
     try {
       const output282 = path.join(outputDir, 'saida282.txt');
       await processarArquivo282Telhaco(inputExcelPath, output282);
-      await this.uploadIfNotEmpty('regra282', output282, codigoSistema, result);
+      await uploadIfNotEmpty(this.supabaseService, 'regra282', output282, codigoSistema, result);
     } catch {}
 
     // Regra 283
     try {
       const output283 = path.join(outputDir, 'saida283.txt');
       await processarArquivo283Telhaco(inputExcelPath, output283);
-      await this.uploadIfNotEmpty('regra283', output283, codigoSistema, result);
+      await uploadIfNotEmpty(this.supabaseService, 'regra283', output283, codigoSistema, result);
     } catch {}
 
     // Regra 284
     try {
       const output284 = path.join(outputDir, 'saida284.txt');
       await processarArquivo284_1Telhaco(inputExcelPath, output284);
-      await this.uploadIfNotEmpty('regra284', output284, codigoSistema, result);
+      await uploadIfNotEmpty(this.supabaseService, 'regra284', output284, codigoSistema, result);
     } catch {}
 
     // Regra 328
     try {
       const output328 = path.join(outputDir, 'saida328.txt');
       await processarArquivo328Telhaco(inputExcelPath, output328);
-      await this.uploadIfNotEmpty('regra328', output328, codigoSistema, result);
+      await uploadIfNotEmpty(this.supabaseService, 'regra328', output328, codigoSistema, result);
     } catch {}
 
     // Regra 329
     try {
       const output329 = path.join(outputDir, 'saida329.txt');
       await processarArquivo329Telhaco(inputExcelPath, output329);
-      await this.uploadIfNotEmpty('regra329', output329, codigoSistema, result);
+      await uploadIfNotEmpty(this.supabaseService, 'regra329', output329, codigoSistema, result);
     } catch {}
 
     // Regra 335
     try {
       const output335 = path.join(outputDir, 'saida335.txt');
       await processarArquivo335Telhaco(inputExcelPath, output335);
-      await this.uploadIfNotEmpty('regra335', output335, codigoSistema, result);
+      await uploadIfNotEmpty(this.supabaseService, 'regra335', output335, codigoSistema, result);
     } catch {}
 
     // Regra 336
     try {
       const output336 = path.join(outputDir, 'saida336.txt');
       await processarArquivo336Telhaco(inputExcelPath, output336);
-      await this.uploadIfNotEmpty('regra336', output336, codigoSistema, result);
+      await uploadIfNotEmpty(this.supabaseService, 'regra336', output336, codigoSistema, result);
     } catch {}
 
     // Regra 337
     try {
       const output337 = path.join(outputDir, 'saida337.txt');
       await processarArquivo337Telhaco(inputExcelPath, output337);
-      await this.uploadIfNotEmpty('regra337', output337, codigoSistema, result);
+      await uploadIfNotEmpty(this.supabaseService, 'regra337', output337, codigoSistema, result);
     } catch {}
 
     // Regra 347
     try {
       const output347 = path.join(outputDir, 'saida347.txt');
       await processarArquivo347Telhaco(inputExcelPath, output347);
-      await this.uploadIfNotEmpty('regra347', output347, codigoSistema, result);
+      await uploadIfNotEmpty(this.supabaseService, 'regra347', output347, codigoSistema, result);
     } catch {}
 
     // Regra 349
     try {
       const output349 = path.join(outputDir, 'saida349.txt');
       await processarArquivo349Telhaco(inputExcelPath, output349);
-      await this.uploadIfNotEmpty('regra349', output349, codigoSistema, result);
+      await uploadIfNotEmpty(this.supabaseService, 'regra349', output349, codigoSistema, result);
     } catch {}
 
     // Regra 350
     try {
       const output350 = path.join(outputDir, 'saida350.txt');
       await processarArquivo350Telhaco(inputExcelPath, output350);
-      await this.uploadIfNotEmpty('regra350', output350, codigoSistema, result);
+      await uploadIfNotEmpty(this.supabaseService, 'regra350', output350, codigoSistema, result);
     } catch {}
 
     return result;

--- a/backend/src/strategies/TelhasProcessor.ts
+++ b/backend/src/strategies/TelhasProcessor.ts
@@ -22,38 +22,12 @@ import { processarArquivo350 as processarArquivo350 } from 'src/Regras/TELHAS/35
 import { exportToTxt289 } from 'src/Regras/TELHAÇO/289/ProcessarArquivo289';
 import { Processador326 } from 'src/Regras/TELHAS/326/ProcessarArquivo326';
 import { processarArquivo289Telhas } from 'src/Regras/TELHAS/289/processarArquivo289';
-
-interface ProcessedInfo {
-  path: string;
-  size: number;
-}
+import { ProcessedInfo, uploadIfNotEmpty } from '../utils/upload';
 
 @Injectable()
 export class TelhasProcessor implements IEmpresaProcessor {
   constructor(private readonly supabaseService: SupabaseService) {}
 
-  private async uploadIfNotEmpty(
-    key: string,
-    filePath: string,
-    codigoSistema: string,
-    result: Record<string, ProcessedInfo>,
-  ) {
-    const stats = fs.statSync(filePath);
-    if (stats.size > 0) {
-      const fileBuffer = fs.readFileSync(filePath);
-      const { supabasePath, error } = await this.supabaseService.uploadProcessedFile(
-        filePath,
-        fileBuffer,
-        codigoSistema,
-      );
-      result[key] = {
-        path: supabasePath,
-        size: stats.size,
-      };
-    } else {
-      fs.unlinkSync(filePath); // remove vazios
-    }
-  }
 
   async processUnificado(
     inputExcelPath: string,
@@ -66,98 +40,98 @@ export class TelhasProcessor implements IEmpresaProcessor {
     try {
       const output255 = path.join(outputDir, 'saida255.txt');
       await processarArquivo255Telhas(inputExcelPath, output255);
-      await this.uploadIfNotEmpty('regra255', output255, codigoSistema, result);
+      await uploadIfNotEmpty(this.supabaseService, 'regra255', output255, codigoSistema, result);
     } catch {}
 
     //257_1
     try {
       const output257_1 = path.join(outputDir, 'saida257_1.txt');
       await processarArquivos257_1Telhas(inputExcelPath, output257_1);
-      await this.uploadIfNotEmpty('regra257_1', output257_1, codigoSistema, result);
+      await uploadIfNotEmpty(this.supabaseService, 'regra257_1', output257_1, codigoSistema, result);
     } catch {}
 
     //257_2
     try {
       const output257_2 = path.join(outputDir, 'saida257_2.txt');
       await processarArquivo257_2Telhas(inputExcelPath, output257_2);
-      await this.uploadIfNotEmpty('regra257_2', output257_2, codigoSistema, result);
+      await uploadIfNotEmpty(this.supabaseService, 'regra257_2', output257_2, codigoSistema, result);
     } catch {}
 
     //282
     try {
       const output282 = path.join(outputDir, 'saida282.txt');
       await processarArquivo282Telhas(inputExcelPath, output282);
-      await this.uploadIfNotEmpty('regra282', output282, codigoSistema, result);
+      await uploadIfNotEmpty(this.supabaseService, 'regra282', output282, codigoSistema, result);
     } catch {}
 
     //283
     try {
       const output283 = path.join(outputDir, 'saida283.txt');
       await processarArquivo283Telhas(inputExcelPath, output283);
-      await this.uploadIfNotEmpty('regra283', output283, codigoSistema, result);
+      await uploadIfNotEmpty(this.supabaseService, 'regra283', output283, codigoSistema, result);
     } catch {}
 
     //284
     try {
       const output284 = path.join(outputDir, 'saida284.txt');
       await processarArquivo284_1Telhas(inputExcelPath, output284);
-      await this.uploadIfNotEmpty('regra284', output284, codigoSistema, result);
+      await uploadIfNotEmpty(this.supabaseService, 'regra284', output284, codigoSistema, result);
     } catch {}
 
     // 328
     try {
       const output328 = path.join(outputDir, 'saida328.txt');
       await processarArquivo328Telhas(inputExcelPath, output328);
-      await this.uploadIfNotEmpty('regra328', output328, codigoSistema, result);
+      await uploadIfNotEmpty(this.supabaseService, 'regra328', output328, codigoSistema, result);
     } catch {}
 
     // 329
     try {
       const output329 = path.join(outputDir, 'saida329.txt');
       await processarArquivo329Telhas(inputExcelPath, output329);
-      await this.uploadIfNotEmpty('regra329', output329, codigoSistema, result);
+      await uploadIfNotEmpty(this.supabaseService, 'regra329', output329, codigoSistema, result);
     } catch {}
 
     // 335
     try {
       const output335 = path.join(outputDir, 'saida335.txt');
       await processarArquivo335Telhas(inputExcelPath, output335);
-      await this.uploadIfNotEmpty('regra335', output335, codigoSistema, result);
+      await uploadIfNotEmpty(this.supabaseService, 'regra335', output335, codigoSistema, result);
     } catch {}
 
     // 336
     try {
       const output336 = path.join(outputDir, 'saida336.txt');
       await processarArquivo336Telhas(inputExcelPath, output336);
-      await this.uploadIfNotEmpty('regra336', output336, codigoSistema, result);
+      await uploadIfNotEmpty(this.supabaseService, 'regra336', output336, codigoSistema, result);
     } catch {}
 
     // 337
     try {
       const output337 = path.join(outputDir, 'saida337.txt');
       await processarArquivo337Telhas(inputExcelPath, output337);
-      await this.uploadIfNotEmpty('regra337', output337, codigoSistema, result);
+      await uploadIfNotEmpty(this.supabaseService, 'regra337', output337, codigoSistema, result);
     } catch {}
 
     // 347
     try {
       const output347 = path.join(outputDir, 'saida347.txt');
       await processarArquivo347Telhas(inputExcelPath, output347);
-      await this.uploadIfNotEmpty('regra347', output347, codigoSistema, result);
+      await uploadIfNotEmpty(this.supabaseService, 'regra347', output347, codigoSistema, result);
     } catch {}
 
     // 349
     try {
       const output349 = path.join(outputDir, 'saida349.txt');
       await processarArquivo349Telhas(inputExcelPath, output349);
-      await this.uploadIfNotEmpty('regra349', output349, codigoSistema, result);
+      await uploadIfNotEmpty(this.supabaseService, 'regra349', output349, codigoSistema, result);
     } catch {}
 
     // 350
     try {
       const output350 = path.join(outputDir, 'saida350.txt');
       await processarArquivo350(inputExcelPath, output350);
-      await this.uploadIfNotEmpty('regra350', output350, codigoSistema, result);
+      await uploadIfNotEmpty(this.supabaseService, 'regra350', output350, codigoSistema, result);
     } catch {}
 
     return result;

--- a/backend/src/utils/upload.ts
+++ b/backend/src/utils/upload.ts
@@ -1,0 +1,31 @@
+import * as fs from 'fs';
+import { SupabaseService } from '../supabase/supabase.service';
+
+export interface ProcessedInfo {
+  path: string;
+  size: number;
+}
+
+export async function uploadIfNotEmpty(
+  supabaseService: SupabaseService,
+  key: string,
+  filePath: string,
+  codigoSistema: string,
+  result: Record<string, ProcessedInfo>,
+): Promise<void> {
+  const stats = fs.statSync(filePath);
+  if (stats.size > 0) {
+    const fileBuffer = fs.readFileSync(filePath);
+    const { supabasePath, error } = await supabaseService.uploadProcessedFile(
+      filePath,
+      fileBuffer,
+      codigoSistema,
+    );
+    result[key] = {
+      path: supabasePath,
+      size: stats.size,
+    };
+  } else {
+    fs.unlinkSync(filePath);
+  }
+}


### PR DESCRIPTION
## Summary
- add `uploadIfNotEmpty` utility
- refactor processors to use the new helper for file upload logic

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684318547c30832d9b8be74aeb5b00c1